### PR TITLE
Fixed Travis Auto-build Test Script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,8 @@ before_script:
  # https://github.com/arduino/Arduino/issues/1981
  - Xvfb :1 -screen 0 1024x768x16 &> xvfb.log &
  # put your source files in a folder under a new libraries folder
- - sudo mkdir /usr/src/arduino
- - sudo mkdir /usr/src/arduino/libraries
- - sudo ln -s $TRAVIS_BUILD_DIR/FabScanArduinoFirmware /usr/src/arduino/libraries/FabScanArduinoFirmware
+ - sudo mkdir -p /usr/src/arduino/libraries
+ - sudo ln -s $TRAVIS_BUILD_DIR/$NAME /usr/src/arduino/libraries/$NAME
 
 script:
- - sudo DISPLAY=:1.0 /usr/local/share/arduino/arduino --board $BOARD --pref sketchbook.path=/usr/src/arduino --verify /usr/src/arduino/libraries/something/examples/$NAME/$NAME.ino
+ - sudo DISPLAY=:1.0 /usr/local/share/arduino/arduino --board $BOARD --pref sketchbook.path=/usr/src/arduino --verify /usr/src/arduino/libraries/$NAME/$NAME.ino

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
  - Xvfb :1 -screen 0 1024x768x16 &> xvfb.log &
  # put your source files in a folder under a new libraries folder
  - sudo mkdir -p /usr/src/arduino/libraries
- - sudo ln -s $TRAVIS_BUILD_DIR/$NAME /usr/src/arduino/libraries/$NAME
+ # sudo ln -s $TRAVIS_BUILD_DIR/$NAME /usr/src/arduino/libraries/$NAME
 
 script:
- - sudo DISPLAY=:1.0 /usr/local/share/arduino/arduino --board $BOARD --pref sketchbook.path=/usr/src/arduino --verify /usr/src/arduino/libraries/$NAME/$NAME.ino
+ - sudo DISPLAY=:1.0 /usr/local/share/arduino/arduino --board $BOARD --pref sketchbook.path=/usr/src/arduino --verify $TRAVIS_BUILD_DIR/$NAME/$NAME.ino


### PR DESCRIPTION
- Fixed the source path in .travis.yml so that the Travis Auto-build test script will work correctly to verify the FabScanArduinoFirmware sketch.
- Removed the symbolic link of the FabScanArduinoFirmware source to the sketchbook path libraries folder in the Travis before_script logic.  Since FabScanArduinoFirmware is a sketch instead of a library, having it in the libraries folder was causing a redundant include of source files from two paths, resulting in a build failure.

Travis now works correctly for testing FabScanArduinoFirmware.
