### PR TITLE
Support for grbl CNCSHIELD

### DIFF
--- a/FabScanArduinoFirmware/boards.h
+++ b/FabScanArduinoFirmware/boards.h
@@ -6,6 +6,7 @@
 #define BOARD_FABSCANPI             1    
 #define BOARD_CYCLOP                2
 #define BOARD_SANGUINOLOLU          3
+#define BOARD_CNCSHIELD             4
 
 #define MB(board) (MOTHERBOARD==BOARD_##board)
 

--- a/FabScanArduinoFirmware/configuration.h
+++ b/FabScanArduinoFirmware/configuration.h
@@ -17,13 +17,14 @@
  * The following define selects which electronics board you have.
  * Please choose the name from boards.h that matches your setup.
  * Some possible Values are:
- * 
+ *
  * BOARD_FABSCANPI    - FabScanPi Hat for Raspberry Pi
  * BOARD_CYCLOP       - Cyclop Scanner ZUM Scan Board
  * BOARD_SANGUINOLOLU - Sanguinololu 3D Printer Board v 1.3
- * 
+ * BOARD_CNCSHIELD - Arduino Uno with CNC shield V3.0 or newer (see grbl project for pinout)
+ *
  */
- 
+
 #ifndef MOTHERBOARD
   #define MOTHERBOARD BOARD_FABSCANPI
 #endif

--- a/FabScanArduinoFirmware/pins.h
+++ b/FabScanArduinoFirmware/pins.h
@@ -8,6 +8,8 @@
  #include "pins_CYCLOP.h"
 #elif MB(SANGOINOLOLU)
  #include "pins_SANGOINOLOLU.h"
+#elif MB(CNCSHIELD)
+ #include "pins_CNCSHIELD.h"
 #endif
 
 #endif

--- a/FabScanArduinoFirmware/pins_CNCSHIELD.h
+++ b/FabScanArduinoFirmware/pins_CNCSHIELD.h
@@ -1,0 +1,53 @@
+#ifndef PINS_CNCSHIELD_H
+#define PINS_CNCSHIELD_H
+
+/*
+ * Laser 
+ */
+//LIMIT SWITCH Z AXIS ON CNC SHIELD
+#define RIGHT_LASER_PIN 11
+//SPINDLE ENABLE PIN ON CNC SHIELD
+#define LEFT_LASER_PIN 12
+
+//NOT USED ON CNC SHIELD
+#define MICROSTEP   A5
+
+/*
+ * Turntable Stepper
+ */
+//X AXIS ON CNC SHIELD
+#define ENABLE_PIN_0  8
+#define STEP_PIN_0    2
+#define DIR_PIN_0     5
+
+/**
+ * WS2812 LED 
+ */
+// FEED HOLD PIN ON CNC SHIELD
+#define LIGHT_PIN A1
+
+
+/**
+ * Optional Laser Stepper
+ */
+//Y AXIS ON CNC SHIELD
+#define ENABLE_PIN_1  8
+#define STEP_PIN_1    3
+#define DIR_PIN_1     6
+
+ /**
+  * Optional Laser Servos
+  */
+//LIMIT SWITCH X AXIS ON CNC SHIELD
+#define RIGHT_SERVO_PIN 9
+
+//LIMIT SWITCH Y AXIS ON CNC SHIELD
+#define LEFT_SERVO_PIN 10
+
+/**
+ *  STEPPER DEFINES FOR SELECTION
+ */
+#define LASER_STEPPER        11  //0xb
+#define TURNTABLE_STEPPER    10  //0xa
+
+#endif


### PR DESCRIPTION
Added pin definitions for grbl CNCSHIELD.
Define BOARD_CNCSHIELD in configuration.h and recompile firmware if you want to use this feature.